### PR TITLE
Use bitflags in Proc::open() API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Sergio Benitez <sb@sergio.bz>"]
 [dependencies]
 time = "0.1"
 rand = "0.3"
+bitflags = "1.0.4"


### PR DESCRIPTION
Hello! This small PR modifies the Proc::open() API to use bitflags instead of a u32 for better type-safety. 
Awesome project!